### PR TITLE
Wrong http host in livenessProbe

### DIFF
--- a/lesson-14/kuber-deploy-livenessProbe-http-with-host-headers.yaml
+++ b/lesson-14/kuber-deploy-livenessProbe-http-with-host-headers.yaml
@@ -24,7 +24,7 @@ spec:
             path: /
             httpHeaders:
             - name: Host
-              value: kuber-healthy.example.com
+              value: kuber-unhealthy.example.com
             port: 80
           # initialDelaySeconds: 5
           periodSeconds: 5


### PR DESCRIPTION
Тут возможно ошибка в livenessProbe. Запрашивается kuber-healthy.example.com, который никогда не вернет 500. В видео так же прописан kuber-unhealthy.example.com.